### PR TITLE
load ephys memoization ipynb

### DIFF
--- a/notebooks/supplemental/1.0-mjt-load-ephys-memoization.ipynb
+++ b/notebooks/supplemental/1.0-mjt-load-ephys-memoization.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is to compare the timing of the loading and merging of spikes and stims. It demonstrates why any memoization isn't used for the loading of the data."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {


### PR DESCRIPTION
addresses #5 
looks like its not worth it to implement the memoization.

```Looks like all the time is spent in the the alignment. Its not worth memoizing the loading of spikes and stims, and the alignment has to be done after any shuffling I do.```